### PR TITLE
The entry file name is the same in debug mode

### DIFF
--- a/src/configs/pilet.ts
+++ b/src/configs/pilet.ts
@@ -43,7 +43,7 @@ export async function getPiletConfig(
   setEnvironment(variables);
 
   function getFileName() {
-    const name = develop ? 'index.dev' : 'index';
+    const name = develop ? 'index.pilet.dev' : 'index';
     return `${name}.js`;
   }
 


### PR DESCRIPTION
In the pilet debugging mode, the pilet entry file `index.dev.js` conflicted with the piral entry file, resulting in a white screen.
![image](https://user-images.githubusercontent.com/5674761/80864862-20c6ec00-8cb8-11ea-8658-d6fb4289d6a2.png)

For example, the pilet entry file can be named `index.pilet.dev` to solve the problem.
![image](https://user-images.githubusercontent.com/5674761/80864899-5e2b7980-8cb8-11ea-803a-9a1dfc892f3f.png)
