### PR TITLE
Support https and custom host

### DIFF
--- a/packages/piral-cli-webpack/src/configs/pilet.ts
+++ b/packages/piral-cli-webpack/src/configs/pilet.ts
@@ -56,7 +56,7 @@ export async function getPiletConfig(
           res.json({
             name: piletPkg.name,
             version: piletPkg.version,
-            link: `http://localhost:${port}/${fileName}`,
+            link: `/${fileName}`,
             hash: '0',
             noCache: true,
             custom: piletPkg.custom,


### PR DESCRIPTION
Remove protocol and host for automatic adaptation.
![image](https://user-images.githubusercontent.com/5674761/83959264-5c536800-a8ad-11ea-8bf9-b57fa627e3c0.png)
Works fine on chrome of mac notebook.